### PR TITLE
Update categories group when updating subscription prefs

### DIFF
--- a/lib/ello/kinesis_consumer/mailchimp_processor.rb
+++ b/lib/ello/kinesis_consumer/mailchimp_processor.rb
@@ -7,8 +7,7 @@ module Ello
 
       def user_was_created(record)
         mailchimp.upsert_to_users_list record['email'],
-                                       record['subscription_preferences'],
-                                       record['followed_categories'] || []
+                                       record['subscription_preferences']
       end
 
       def user_changed_email(record)
@@ -17,7 +16,9 @@ module Ello
       end
 
       def user_changed_subscription_preferences(record)
-        mailchimp.upsert_to_users_list record['email'], record['subscription_preferences']
+        mailchimp.upsert_to_users_list record['email'],
+                                       record['subscription_preferences'],
+                                       record['followed_categories'] || []
       end
 
       def user_was_deleted(record)

--- a/spec/ello/kinesis_consumer/mailchimp_processor_spec.rb
+++ b/spec/ello/kinesis_consumer/mailchimp_processor_spec.rb
@@ -45,8 +45,7 @@ describe Ello::KinesisConsumer::MailchimpProcessor, freeze_time: true do
             'onboarding_drip' => true,
             'daily_ello' => true,
             'weekly_ello' => false
-          },
-          ['Art'])
+          })
         processor.run!
       end
     end
@@ -91,6 +90,7 @@ describe Ello::KinesisConsumer::MailchimpProcessor, freeze_time: true do
           'email' => 'jay@ello.co',
           'created_at' => Time.now.to_f,
           'has_experimental_features' => false,
+          'followed_categories' => %w(Art Writing),
           'subscription_preferences' => {
             'users_email_list' => true,
             'onboarding_drip' => true,
@@ -108,7 +108,8 @@ describe Ello::KinesisConsumer::MailchimpProcessor, freeze_time: true do
             'onboarding_drip' => true,
             'daily_ello' => true,
             'weekly_ello' => true
-          })
+          },
+          %w(Art Writing))
         processor.run!
       end
     end


### PR DESCRIPTION
- We were initially including the followed categories preferences in
the `user_was_created` event which was firing off before a new user 
selected their categories.