### PR TITLE
Locked events

### DIFF
--- a/lib/ello/kinesis_consumer/knowtify_processor.rb
+++ b/lib/ello/kinesis_consumer/knowtify_processor.rb
@@ -103,6 +103,7 @@ module Ello
       def user_was_locked(record)
         knowtify_client.delete [ record['email'] ]
       end
+      add_transaction_tracer :user_was_locked, category: :task
 
       def user_was_unlocked(record)
         begin
@@ -121,6 +122,7 @@ module Ello
           @logger.error "Unable to parse date: #{record['created_at']}"
         end
       end
+      add_transaction_tracer :user_was_unlocked, category: :task
 
       private
 

--- a/lib/ello/kinesis_consumer/knowtify_processor.rb
+++ b/lib/ello/kinesis_consumer/knowtify_processor.rb
@@ -100,6 +100,28 @@ module Ello
       end
       add_transaction_tracer :user_was_deleted, category: :task
 
+      def user_was_locked(record)
+        knowtify_client.delete [ record['email'] ]
+      end
+
+      def user_was_unlocked(record)
+        begin
+          knowtify_client.upsert [{ email: record['email'],
+                                    name: record['username'],
+                                    data: {
+                                      username: record['username'],
+                                      subscribed_to_users_email_list: record['subscription_preferences']['users_email_list'],
+                                      subscribed_to_daily_ello: record['subscription_preferences']['daily_ello'],
+                                      subscribed_to_weekly_ello: record['subscription_preferences']['weekly_ello'],
+                                      subscribed_to_onboarding_drip: record['subscription_preferences']['onboarding_drip'],
+                                      created_at: Time.at(record['created_at']).to_datetime
+                                    }
+          }]
+        rescue TypeError
+          @logger.error "Unable to parse date: #{record['created_at']}"
+        end
+      end
+
       private
 
       def knowtify_client

--- a/lib/ello/kinesis_consumer/mailchimp_processor.rb
+++ b/lib/ello/kinesis_consumer/mailchimp_processor.rb
@@ -68,12 +68,18 @@ module Ello
       def user_was_locked(record)
         mailchimp.remove_from_users_list record['email']
       end
+      add_transaction_tracer :user_was_locked, category: :task
 
       def user_was_unlocked(record)
         mailchimp.upsert_to_users_list email: record['email'],
                                        preferences: record['subscription_preferences'],
+                                       categories: record['followed_categories'] || [],
+                                       featured_categories: record['featured_categories'] || [],
+
+                                       merge_fields: merge_fields_for_user(record, {ACCOUNT: 'TRUE'}),
                                        force_resubscribe: false
       end
+      add_transaction_tracer :user_was_unlocked, category: :task
 
       private
 

--- a/lib/ello/kinesis_consumer/mailchimp_processor.rb
+++ b/lib/ello/kinesis_consumer/mailchimp_processor.rb
@@ -65,6 +65,16 @@ module Ello
       end
       add_transaction_tracer :user_token_granted, category: :task
 
+      def user_was_locked(record)
+        mailchimp.remove_from_users_list record['email']
+      end
+
+      def user_was_unlocked(record)
+        mailchimp.upsert_to_users_list email: record['email'],
+                                       preferences: record['subscription_preferences'],
+                                       force_resubscribe: false
+      end
+
       private
 
       def mailchimp

--- a/spec/ello/kinesis_consumer/mailchimp_processor_spec.rb
+++ b/spec/ello/kinesis_consumer/mailchimp_processor_spec.rb
@@ -299,32 +299,77 @@ describe Ello::KinesisConsumer::MailchimpProcessor, freeze_time: true do
 
     describe 'when presented with a UserWasUnlocked event' do
       let(:schema_name) { 'user_was_unlocked' }
+      let(:created_at) { 1484598233.868098 }
       let(:record) do
         {
-          'email' => 'jz@ello.co',
-          'previous_email' => 'jay@ello.co',
-          'username' => 'jayzes',
-          'created_at' => Time.now.to_f,
-          'has_experimental_features' => true,
+          'username' => 'testuser',
+          'locked_at' => nil,
+          'locked_reason' => nil,
+          'name' => 'jay',
+          'email' => 'jay@ello.co',
+          'created_at' => created_at,
+          'has_experimental_features' => false,
+          'views_adult_content' => false,
+          'is_hireable' => true,
+          'is_featured' => true,
+          'followed_categories' => %w(Art Writing),
+          'featured_categories' => %w(Art),
           'subscription_preferences' => {
             'users_email_list' => true,
             'onboarding_drip' => true,
             'daily_ello' => true,
-            'weekly_ello' => false
+            'weekly_ello' => true
           }
         }
       end
 
       it 'creates the record in Mailchimp' do
-        expect_any_instance_of(MailchimpWrapper).to receive(:upsert_to_users_list).with(
-          email: 'jz@ello.co',
+        expect_any_instance_of(MailchimpWrapper).to receive(:upsert_to_users_list).with({
+          email: 'jay@ello.co',
+          force_resubscribe: false,
           preferences: {
             'users_email_list' => true,
             'onboarding_drip' => true,
             'daily_ello' => true,
-            'weekly_ello' => false
+            'weekly_ello' => true
           },
-          force_resubscribe: false)
+          categories: %w(Art Writing),
+          featured_categories: %w(Art),
+          merge_fields: {
+            USERNAME: 'testuser',
+            NAME: 'jay',
+            HAS_AVATAR: 'NIL',
+            HAS_COVER: 'NIL',
+            HAS_BIO: 'NIL',
+            HAS_LINKS: 'NIL',
+            LOCATION: nil,
+            ISFEATURED: 'TRUE',
+
+            CREATED_AT: "01/16/2017",
+            UPDATED_AT: nil,
+            LAST_SEEN: nil,
+            LAST_POST: nil,
+            LAST_CMMNT: nil,
+            LAST_LOVE: nil,
+
+            LOVES_GVN: nil,
+            POSTS: nil,
+            # FOLLOWERS: nil,
+            FOLLOWING: nil,
+            INVITES: nil,
+            COMMENTS: nil,
+            REPOSTS: nil,
+            # LOVES_RCVD: nil,
+            # CMMNT_RCVD: nil,
+            SALEABLE: nil,
+
+            COLLAB: 'NIL',
+            HIREABLE: 'TRUE',
+            VIEWS_NSFW: 'FALSE',
+
+            ACCOUNT: 'TRUE',
+          }
+        })
         processor.run!
       end
     end


### PR DESCRIPTION
Not sure if we need `add_transaction_tracer` for these events, so I left them out. The events don't seem all that intensive.