### PR TITLE
Force resubscribe when a user is unlocked

### DIFF
--- a/lib/ello/kinesis_consumer/mailchimp_processor.rb
+++ b/lib/ello/kinesis_consumer/mailchimp_processor.rb
@@ -79,7 +79,7 @@ module Ello
                                        featured_categories: record['featured_categories'] || [],
 
                                        merge_fields: merge_fields_for_user(record, {ACCOUNT: 'TRUE'}),
-                                       force_resubscribe: false
+                                       force_resubscribe: true
       end
       add_transaction_tracer :user_was_unlocked, category: :task
 

--- a/spec/ello/kinesis_consumer/mailchimp_processor_spec.rb
+++ b/spec/ello/kinesis_consumer/mailchimp_processor_spec.rb
@@ -337,7 +337,7 @@ describe Ello::KinesisConsumer::MailchimpProcessor, freeze_time: true do
       it 'creates the record in Mailchimp' do
         expect_any_instance_of(MailchimpWrapper).to receive(:upsert_to_users_list).with({
           email: 'jay@ello.co',
-          force_resubscribe: false,
+          force_resubscribe: true,
           preferences: {
             'users_email_list' => true,
             'onboarding_drip' => true,


### PR DESCRIPTION
- This was trying to subscribe-if-new on an account that already exists.