### PR TITLE
Remove periods from email addresses in skip list

### DIFF
--- a/lib/ello/mailchimp_wrapper.rb
+++ b/lib/ello/mailchimp_wrapper.rb
@@ -32,7 +32,7 @@ class MailchimpWrapper
   private
 
   def skip_list
-    (ENV['EMAILS_TO_SKIP'] || '').split(',').map(&:strip)
+    (ENV['EMAILS_TO_SKIP'] || '').split(',').map { |email| email.tr('.', '') }.map(&:strip)
   end
 
   def users_list


### PR DESCRIPTION
- This will help with our spam issues where spammers will use variations
of the same email address using periods